### PR TITLE
Usar o vscode test runner para os testes da extensão

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1957,14 +1957,12 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -1979,20 +1977,17 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -2109,8 +2104,7 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -2122,7 +2116,6 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2137,7 +2130,6 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -2145,14 +2137,12 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -2171,7 +2161,6 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -2252,8 +2241,7 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2265,7 +2253,6 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2387,7 +2374,6 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"compile": "tsc -p ./src",
 		"tslint": "tslint ./src/**/*.ts",
 		"watch": "tsc -w -p ./src",
-		"test": "mocha -u tdd ./out/tests/",
+		"test": "node node_modules/vscode/bin/test",
 		"postinstall": "node ./node_modules/vscode/bin/install",
 		"package": "vsce package",
 		"publish": "vsce publish"

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,0 +1,16 @@
+import Utils from '../utils';
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as path from 'path';
+
+suite("Utils Tests", function() {
+
+	// Defines a Mocha unit test
+	test("getVSCodePath", function() {
+		let rootPath: string = vscode.workspace.rootPath || process.cwd();
+		let vscodePath: string = Utils.getVSCodePath();
+
+		assert.equal(vscodePath, path.join(rootPath, '.vscode'));
+	});
+
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,7 @@ export default class Utils {
 	/**
 	 * Subscrição para evento de chave de compilação.
 	 */
-	static get onDidSelectedKey(): vscode.Event<string>{
+	static get onDidSelectedKey(): vscode.Event<string> {
 		return Utils._onDidSelectedKey.event;
 	}
 
@@ -68,14 +68,18 @@ export default class Utils {
  * Retorna o path completo do launch.json
  */
 	static getLaunchConfigFile() {
-		return vscode.workspace.rootPath + "/.vscode/launch.json";
+		let rootPath: string = vscode.workspace.rootPath || process.cwd();
+
+		return path.join(rootPath, ".vscode", "launch.json");
 	}
 
 	/**
 	 * Retorna o path da pastar .vscode dentro do workspace
 	 */
 	static getVSCodePath() {
-		return vscode.workspace.rootPath + "/.vscode";
+		let rootPath: string = vscode.workspace.rootPath || process.cwd();
+
+		return path.join(rootPath, ".vscode");
 	}
 
 	/**
@@ -154,7 +158,7 @@ export default class Utils {
 	}
 
 	/**
-	 *Deleta o servidor logado por ultimo do servers.json
+	 * Deleta o servidor logado por ultimo do servers.json
 	 */
 	static deleteSelectServer() {
 		const servers = this.getServersConfig();
@@ -180,8 +184,8 @@ export default class Utils {
 	}
 
 	/**
- *Deleta o servidor logado por ultimo do servers.json
- */
+	 * Deleta o servidor logado por ultimo do servers.json
+	 */
 	static deleteServer(id: string) {
 		const allConfigs = this.getServersConfig();
 
@@ -213,9 +217,9 @@ export default class Utils {
 	}
 
 	/**
- * Grava no arquivo launch.json uma nova configuracao de launchs
- * @param JSONServerInfo
- */
+	 * Grava no arquivo launch.json uma nova configuracao de launchs
+	 * @param JSONServerInfo
+	 */
 	static persistLaunchsInfo(JSONLaunchInfo) {
 		let fs = require('fs');
 		fs.writeFileSync(Utils.getLaunchConfigFile(), JSON.stringify(JSONLaunchInfo, null, "\t"), (err) => {
@@ -281,12 +285,12 @@ export default class Utils {
 
 		this.persistServersInfo(config);
 		Utils._onDidSelectedKey.fire(infos);
-		}
+	}
 
 	/**
 	 * Recupera a lista de includes do arquivod servers.json
 	 */
-	static getIncludes(absolutePath: boolean = false):Array<string> {
+	static getIncludes(absolutePath: boolean = false): Array<string> {
 		const servers = this.getServersConfig();
 		const includes: Array<string> = servers.includes as Array<string>;
 


### PR DESCRIPTION
Alterado o comando para teste para que seja possível testar métodos que usam `import x from 'vscode'`.

Incluído um teste básico para `Utils.getVSCodePath` (src/utils.ts)