### PR TITLE
Corrigido a indentação do último Return nas Functions

### DIFF
--- a/src/formatter/formmatingRules.ts
+++ b/src/formatter/formmatingRules.ts
@@ -193,6 +193,11 @@ export class FormattingRules {
 			begin: /^(\s+)?(begin)(\s+)?(sequence)/i,
 			middle: /^(\s+)?(recover)(\s+)?(sequence)/i,
 			end: /^(\s+)?(end)(\s+)?(sequence)?/i
+		},
+		{
+			id: 'function',
+			begin: /^(\s+)?((\w+)(\s+))?(function)(\s+)(\w+)/i,
+			end: /^(\s+)?(return)(\s+)/i
 		}
 		];
 	}


### PR DESCRIPTION
Ao fazer a indentação do código, o último Return estava avançando como se fosse uma nova estrutura, ao invés de ficar no mesmo nível da abertura da Function.