### PR TITLE
Correção function-call para keywords

### DIFF
--- a/syntaxes/advpl_language.tmLanguage.json
+++ b/syntaxes/advpl_language.tmLanguage.json
@@ -244,8 +244,8 @@
 		},
 		"function-call" : {
 			"name": "meta.function.call.advpl",
-			"begin": "\\s*(\\w+)(\\()",
-			"end" : "(\\))",
+			"begin": "(\\w+)(?=\\()",
+			"end" : "(?<=\\))",
 			"beginCaptures": {
 				"1" : {"name": "entity.name.function.call.functionName.advpl"}
 			},


### PR DESCRIPTION
Correção de syntax para considerar keywords quando utilizadas com " ( ".

Ex:
  If( )
  Elseif( )
  Endif