### PR TITLE
 Adiciona filtro por extensão na geração de patchs por pasta - Fixed #106

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"vscode-debugadapter": "1.32.1",
 		"vscode-languageclient": "^4.4.2",
 		"vscode-nls": "^4.1.1",
+		"watch": "^1.0.2",
 		"zlib": "^1.0.5"
 	},
 	"devDependencies": {
@@ -73,7 +74,7 @@
 		"tslint": "5.11.0",
 		"typescript": "3.1.6",
 		"vsce": "^1.64.0",
-		"vscode": "^1.1.34",
+		"vscode": "^1.1.35",
 		"vscode-debugadapter-testsupport": "1.32.0",
 		"vscode-nls-dev": "^3.2.6"
 	},
@@ -187,6 +188,12 @@
 					"type": "array",
 					"default": [],
 					"description": "%tds.package.args.for.lsp%"
+				},
+				"totvsLanguageServer.extensions_folder_patch": {
+					"scope":"resource",
+					"type": "String",
+					"default": "'.PRW','.PRX','.PRG','.APW','.APH','.TRES','.PNG','.BMP','.RES','.APL','.TLPP','.4GL'",
+					"description": "%tds.package.extensions_folder_patch%"
 				},
 				"totvsLanguageServer.maxNumberOfProblems": {
 					"scope": "resource",

--- a/package.nls.json
+++ b/package.nls.json
@@ -99,5 +99,6 @@
 	"tds.package.editor.toggle.autocomplete": "Toggle Autocomplete Behavior.",
     "tds.package.editor.toggle.autocomplete.basic": "Standard VS Cdoe procedure.",
 	"tds.package.editor.toggle.autocomplete.ls": "Search in the Language Server of the current environment.",
-	"tds.command.debug.toggleTableSync": "Toggle table sync"
+	"tds.command.debug.toggleTableSync": "Toggle table sync",
+	"tds.package.extensions_folder_patch": "Lista de extensões permitidas para compilar via pasta"
 }

--- a/src/patch/patchGenerate.ts
+++ b/src/patch/patchGenerate.ts
@@ -222,13 +222,23 @@ function sendPatchGenerateMessage(server, patchMaster, patchDest, patchType, pat
 function readFiles(dirname: string, allFilesNames: Array<String>, allFilesFullPath: Array<string>, onError: any) {
 	let filenames = fs.readdirSync(dirname);
 
+	// Filtro por extensão de arquivo conhecidos
+
+	let aTpFilesToCompile = ['.PRW','.PRX','.PRG','.APW','.APH','.TRES','.PNG','.BMP','.RES','.APL','.TLPP','.4GL'];
+
+
 	filenames.forEach(function(filename) {
 		let fullPath = path.join(dirname, filename);
-		if(fs.statSync(fullPath).isDirectory()) {
+		if(fs.statSync(fullPath).isDirectory() && fs.statSync(fullPath)) {
 			readFiles(fullPath, allFilesNames, allFilesFullPath, onError);
 		} else  {
-			allFilesNames.push(filename);
-			allFilesFullPath.push(fullPath);
+
+			if(aTpFilesToCompile.indexOf(path.extname(filename).toUpperCase()) != -1 ){
+
+		    	allFilesNames.push(filename);
+			    allFilesFullPath.push(fullPath);
+
+			}
 		}
 	});
 }

--- a/src/patch/patchGenerate.ts
+++ b/src/patch/patchGenerate.ts
@@ -224,7 +224,22 @@ function readFiles(dirname: string, allFilesNames: Array<String>, allFilesFullPa
 
 	// Filtro por extensão de arquivo conhecidos
 
-	let aTpFilesToCompile = ['.PRW','.PRX','.PRG','.APW','.APH','.TRES','.PNG','.BMP','.RES','.APL','.TLPP','.4GL'];
+	let configADVPL = vscode.workspace.getConfiguration('totvsLanguageServer');//busca o arquivo de configuração
+
+	let extensionsADVPL: any;
+
+	extensionsADVPL = configADVPL.get("extensions_folder_patch",true) ; // Le a chave especifica
+
+	let aTpFilesToCompile = extensionsADVPL.split(",");
+
+	if (aTpFilesToCompile.length > 0){
+
+		aTpFilesToCompile = extensionsADVPL
+
+	}
+
+
+	//let aTpFilesToCompile = ['.PRW','.PRX','.PRG','.APW','.APH','.TRES','.PNG','.BMP','.RES','.APL','.TLPP','.4GL'];
 
 
 	filenames.forEach(function(filename) {
@@ -233,10 +248,25 @@ function readFiles(dirname: string, allFilesNames: Array<String>, allFilesFullPa
 			readFiles(fullPath, allFilesNames, allFilesFullPath, onError);
 		} else  {
 
+			if (aTpFilesToCompile.length > 0){
+
+				aTpFilesToCompile = extensionsADVPL
+
+
 			if(aTpFilesToCompile.indexOf(path.extname(filename).toUpperCase()) != -1 ){
 
 		    	allFilesNames.push(filename);
-			    allFilesFullPath.push(fullPath);
+				allFilesFullPath.push(fullPath);
+
+			}
+
+			else{
+
+				allFilesNames.push(filename);
+				allFilesFullPath.push(fullPath);
+
+
+			}
 
 			}
 		}


### PR DESCRIPTION
Corrige a rotina de geracao de patch por pasta  …
Filtra os arquivos pela extensão para gerar
a patch por pasta.

A configuração deve ser feita pelo arquivo settings.json
da opção workspace.

Filtro Padrão 
'.PRW','.PRX','.PRG','.APW','.APH','.TRES','.PNG','.BMP','.RES','.APL','.TLPP','.4GL'
