### PR TITLE
Fix #129 Adiciona opção de limpar o console antes da compilação

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Ele utiliza os protocolos de comunicação LSP (Language Server Protocol) e DAP 
 
 * Todas as informações sobre os arquivos compilados serão exibidos na visão `Output` (seleção `AdvPL`).
 
+* Caso queira limpar o console antes da compilação, habilite a opção: `File | Preferences | Settings | Extensions | AdvPL | Clear Console Before Compile`.
+
 * Para analisar o resultado da compilação de múltiplos arquivos, existe a opção de abrir uma tabela com informações de todos os arquivos que foram compilados.
 
 * Para exibir essa tabela, selecione mais de um arquivo, compile e após a compilação será apresentada a pergunta a seguir: Clique em `Yes`.

--- a/package.json
+++ b/package.json
@@ -269,6 +269,11 @@
 					"default": true,
 					"description": "%tds.package.show.ask.compile.result%"
 				},
+				"totvsLanguageServer.clearConsoleBeforeCompile": {
+					"type": "boolean",
+					"default": false,
+					"description": "%tds.package.show.clear.console.before.compile%"
+				},
 				"totvsLanguageServer.reconnectLastServer": {
 					"type": "boolean",
 					"default": true,

--- a/package.nls.json
+++ b/package.nls.json
@@ -6,6 +6,7 @@
 	"tds.package.show.welcome.first.initialize": "Show Welcome Page in First Initialize",
 	"tds.package.show.ask.encoding": "Ask for change encoding for Windows-1252",
 	"tds.package.show.ask.compile.result": "Ask for show table with compile results",
+	"tds.package.show.clear.console.before.compile": "Clear console before compile",
 	"tds.package.reconnectLastServer": "Reconnect last connected server on startup.",
 	"tds.package.useReconnectionToken": "Use reconnection token to login.",
 	"tds.package.generate.ppo": "Generate PPO file.",

--- a/src/compile/tdsBuild.ts
+++ b/src/compile/tdsBuild.ts
@@ -51,6 +51,12 @@ async function buildCode(filesPaths: string[], compileOptions: CompileOptions, c
 		return;
 	}
 
+	const configADVPL = vscode.workspace.getConfiguration('totvsLanguageServer');
+	const shouldClearConsole = configADVPL.get("clearConsoleBeforeCompile");
+	if (shouldClearConsole !== false) {
+		languageClient.outputChannel.clear();
+	}
+
 	const resourcesToConfirm: vscode.TextDocument[] = vscode.workspace.textDocuments.filter(d => !d.isUntitled && d.isDirty);
 	const count = resourcesToConfirm.length;
 

--- a/vsc-extension-quickstart.md
+++ b/vsc-extension-quickstart.md
@@ -70,6 +70,8 @@ Ele utiliza os protocolos de comunicação LSP (Language Server Protocol) e DAP 
 
 ### Resultado da compilação
 
+* Caso queira limpar o console antes da compilação, habilite a opção: `File | Preferences | Settings | Extensions | AdvPL | Clear Console Before Compile`.
+
 * Para analisar o resultado da compilação de múltiplos arquivos, exite a opção de abrir uma tabela com informações de todos os arquivos que foram compilados.
 
 * Para exibir essa tabela, selecione mais de um arquivo, compile e após a compilação será apresentada a pergunta a seguir: Clique em `Yes`.


### PR DESCRIPTION
Adiciona nas configurações da extensão uma opção de limpar o Output Advpl antes de iniciar a compilação.