### PR TITLE
Correção de indentação no BeginSQL

### DIFF
--- a/src/formatter/documentFormatting.ts
+++ b/src/formatter/documentFormatting.ts
@@ -49,6 +49,8 @@ export class DocumentFormatting implements DocumentFormattingEditProvider {
 
           if (rule.id === this.ignore_at) {
             this.ignore_at = null;
+          } else if (this.ignore_at) {
+            continue;
           }
 
           if (rule.ignore_at) {


### PR DESCRIPTION
Indentação estava ficando errada quando era encontrada alguma regra dentro do BeginSQL.

Exemplo usando indentação atual:
<img width="281" alt="Screen Shot 2020-12-09 at 17 37 41" src="https://user-images.githubusercontent.com/5282959/101684508-4cc40000-3a45-11eb-8a32-a09564aaecea.png">

O correto seria manter a indentação do usuário:
<img width="269" alt="Screen Shot 2020-12-09 at 17 37 30" src="https://user-images.githubusercontent.com/5282959/101684517-4e8dc380-3a45-11eb-9620-ffd00313c2ee.png">
