### PR TITLE
Corrigir erro de digitação: "serve saved" para "server saved"

### DIFF
--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -327,7 +327,7 @@
   "Could not reconnect to server {0}": "No se puede reconectar con el servidor Cloud",
   "Disconnecting from the server [{0}]": "Desconexión del servidor [{0}]",
   "Rename the server": "Renombrar el Servidor",
-  "Serve saved. Name: {0}": "Servidor grabado",
+  "Server saved. Name: {0}": "Servidor grabado",
   "The server selected is already connected.": "El servidor ya está conectado!",
   "Connecting to the server {0}": "Conectando al servidor {0}",
   "Authenticating user [{0}] in server [{1}]": "Usuario de autenticación [{0}] en el servidor [{1}]",

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -28,7 +28,7 @@
   "Could not reconnect to server {0}": "Could not reconnect to server {0}",
   "Disconnecting from the server [{0}]": "Disconnecting from the server [{0}]",
   "Rename the server": "Rename the server",
-  "Serve saved. Name: {0}": "Serve saved. Name: {0}",
+  "Server saved. Name: {0}": "Server saved. Name: {0}",
   "The server selected is already connected.": "The server selected is already connected.",
   "Connecting to the server {0}": "Connecting to the server {0}",
   "Authenticating user [{0}] in server [{1}]": "Authenticating user [{0}] in server [{1}]",

--- a/l10n/bundle.l10n.pt-BR.json
+++ b/l10n/bundle.l10n.pt-BR.json
@@ -324,7 +324,7 @@
   "Could not reconnect to server {0}": "Não foi possível se reconectar ao servidor",
   "Disconnecting from the server [{0}]": "Desconectando do servidor [{0}]",
   "Rename the server": "Renomear o Servidor",
-  "Serve saved. Name: {0}": "Servidor salvo. Nome: {0}",
+  "Server saved. Name: {0}": "Servidor salvo. Nome: {0}",
   "The server selected is already connected.": "O servidor selecionado já está conectado.",
   "Connecting to the server {0}": "Conectando-se ao servidor {0}",
   "Authenticating user [{0}] in server [{1}]": "Autenticação do usuário [{0}] no servidor [{1}]",

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -28,7 +28,7 @@
   "Could not reconnect to server {0}": "Не удалось повторно подключиться к серверу {0}.",
   "Disconnecting from the server [{0}]": "Отключение от сервера [{0}]",
   "Rename the server": "Переименуйте сервер",
-  "Serve saved. Name: {0}": "Подача сохранена. Имя: {0}",
+  "Server saved. Name: {0}": "Подача сохранена. Имя: {0}",
   "The server selected is already connected.": "Выбранный сервер уже подключен.",
   "Connecting to the server {0}": "Подключение к серверу {0}",
   "Authenticating user [{0}] in server [{1}]": "Аутентификация пользователя [{0}] на сервере [{1}]",

--- a/src/serversView.ts
+++ b/src/serversView.ts
@@ -298,7 +298,7 @@ export class ServersExplorer {
 
       if (serverId !== undefined && showSucess) {
         vscode.window.showInformationMessage(
-          vscode.l10n.t("Serve saved. Name: {0}", serverName)
+          vscode.l10n.t("Server saved. Name: {0}", serverName)
         );
       }
 

--- a/test/e2e/page-objects/workbench-po.ts
+++ b/test/e2e/page-objects/workbench-po.ts
@@ -73,7 +73,7 @@ export class WorkbenchPageObject {
   }
 
   async isSavedServer(): Promise<boolean> {
-    return await this.testNotification(/Serve saved/);
+    return await this.testNotification(/Server saved/);
   }
 
   async isLauncherSaved(): Promise<boolean> {


### PR DESCRIPTION
Esta alteração corrige um erro de digitação onde a frase original era "serve saved" e foi ajustada para "server saved".