### PR TITLE
feat: expor evento onBeforeCompile na API pública da extensão

### DIFF
--- a/src/compile/tdsBuild.ts
+++ b/src/compile/tdsBuild.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { blockBuildCommands, languageClient } from "../extension";
+import { blockBuildCommands, languageClient, fireBeforeCompile } from "../extension";
 import * as fs from "fs";
 import Utils, { ServersConfig } from "../utils";
 
@@ -97,6 +97,7 @@ export function generatePpo(filePath: string, options?: any): Promise<string> {
     compileOptions.returnPpo = true;
 
     if (blockBuildCommands(true)) {
+      fireBeforeCompile(filesUris);
       sendCompilation(
         server,
         includesUris,
@@ -242,6 +243,7 @@ async function buildCode(filesPaths: string[], compileOptions: CompileOptions) {
     }
     //Envia a mensagem de compilacao
     if (blockBuildCommands(true)) {
+      fireBeforeCompile(filesUris);
       sendCompilation(
         server,
         includesUris,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,6 +72,13 @@ import { openWebMonitor } from "./monitor/monitorLoader";
 
 export let languageClient: TotvsLanguageClientA;
 
+let _onBeforeCompile: vscode.EventEmitter<string[]>;
+
+/** Dispara o evento onBeforeCompile. Uso interno — não chamar de fora do módulo de compilação. */
+export function fireBeforeCompile(files: string[]): void {
+  _onBeforeCompile?.fire([...files]);
+}
+
 export function parseUri(u): Uri {
   return Uri.parse(u);
 }
@@ -578,9 +585,11 @@ export function activate(context: ExtensionContext) {
 
   blockBuildCommands(false);
   showBanner();
+  _onBeforeCompile = new vscode.EventEmitter<string[]>();
+  context.subscriptions.push(_onBeforeCompile);
 
   // 'export' public api-surface
-  let exportedApi = {
+  const exportedApi = {
     generatePPO(filePath: string, options?: any): Promise<string> {
       return generatePpo(filePath, options);
     },
@@ -603,7 +612,8 @@ export function activate(context: ExtensionContext) {
     },
     apiTlppTools(message: string): Promise<string> {
       return tlppTools(message);
-    }
+    },
+    onBeforeCompile: _onBeforeCompile.event,
   };
 
   window.showInformationMessage('"TDS-VSCode" is ready.');


### PR DESCRIPTION
Resolve #1481

## O que muda

Adiciona o evento `onBeforeCompile` ao objeto retornado pelo `activate()`, permitindo que extensões externas se inscrevam para receber a lista de arquivos imediatamente antes de cada compilação.

```typescript
const api = await vscode.extensions.getExtension('TOTVS.tds-vscode').activate();
api.onBeforeCompile((fileUris: string[]) => { /* ... */ });
```

## Arquivos alterados

**`src/extension.ts`**
- `EventEmitter<string[]>` privado (`_onBeforeCompile`) declarado no nível do módulo e instanciado dentro de `activate()` — evita gap de reativação em hosts de teste que executam `deactivate` + `activate` no mesmo processo Node.js
- `fireBeforeCompile(files: string[])` exportada para uso interno; o emitter em si não é exportado, garantindo que apenas o módulo de compilação dispare eventos
- `onBeforeCompile: _onBeforeCompile.event` adicionado ao `exportedApi` como accessor read-only
- `_onBeforeCompile` registrado em `context.subscriptions` para dispose automático
- `let exportedApi` → `const exportedApi`

**`src/compile/tdsBuild.ts`**
- `fireBeforeCompile(filesUris)` chamado dentro do bloco `if (blockBuildCommands(true))` em `buildCode()` — o evento só dispara quando a compilação realmente vai ocorrer, não antes do guard
- Mesmo tratamento aplicado ao caminho `generatePpo()` para cobertura consistente
- O array é copiado via spread em `fireBeforeCompile` para isolar o estado dos assinantes do array consumido por `sendCompilation`

## Checklist

- [x] Sem quebra de API pública existente
- [x] Segue o padrão `EventEmitter` já usado na extensão (`_onDidSelectedServer`, `_onDidSelectedKey`)
- [x] Cobre os dois caminhos de compilação (`buildCode` e `generatePpo`)
- [x] Dispose correto via `context.subscriptions`