### PR TITLE
Extend the connected color to parent server groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -320,6 +320,16 @@
           "light": "#11c9cf",
           "highContrast": "#11c9cf"
         }
+      },
+      {
+        "id": "totvsServerExplorer.groupConnectedForeground",
+        "description": "%tds.package.server.view.groupConnectedForeground%",
+        "defaults": {
+          "dark": "#99ff55",
+          "light": "#99ff55",
+          "highContrast": "#99ff55",
+          "highContrastLight": "#99ff55"
+        }
       }
     ],
     "languages": [

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -116,6 +116,7 @@
 	"tds.package.properties.extraParameters.description": "Se utiliza para pasar cualquier parámetro adicional a SC",
 	"tds.package.totvs.language.debug.web": "TOTVS Language Web Debug (HTML de SmartClient)",
 	"tds.package.server.view": "Servidores",
+	"tds.package.server.view.groupConnectedForeground": "Color del icono de un grupo de servidores que contiene un entorno conectado.",
 	"tds.package.properties.program.description.web": "Nombre del programa / función",
 	"tds.package.properties.trace.description.web": "Habilite el registro del protocolo del adaptador de depuración.",
 	"tds.package.properties.smartclientUrl.description": "La URL HTML de SmartClient.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -118,6 +118,7 @@
   "tds.package.properties.extraParameters.description": "Used to pass any extra parameters to SC",
   "tds.package.totvs.language.debug.web": "TOTVS Language Web Debug (SmartClient HTML)",
   "tds.package.server.view": "Servers",
+  "tds.package.server.view.groupConnectedForeground": "Foreground color of a server group icon that contains a connected environment.",
   "tds.package.properties.program.description.web": "Program/Function name",
   "tds.package.properties.trace.description.web": "Enable logging of the Debug Adapter Protocol.",
   "tds.package.properties.smartclientUrl.description": "The SmartClient HTML url.",

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -116,6 +116,7 @@
 	"tds.package.properties.extraParameters.description": "Usado para passar quaisquer parêmetros extras para o SC",
 	"tds.package.totvs.language.debug.web": "Depuração da Web no idioma TOTVS (HTML do SmartClient)",
 	"tds.package.server.view": "Servidores",
+	"tds.package.server.view.groupConnectedForeground": "Cor do ícone de um grupo de servidores que contém um ambiente conectado.",
 	"tds.package.properties.program.description.web": "Nome do programa/função",
 	"tds.package.properties.trace.description.web": "Habilitar o log do protocolo do adaptador de depuração.",
 	"tds.package.properties.smartclientUrl.description": "O URL HTML do SmartClient.",

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -113,6 +113,7 @@
 	"tds.package.properties.extraParameters.description": "Used to pass any extra parameters to SC",
 	"tds.package.totvs.language.debug.web": "Веб-отладка TOTVS Language (SmartClient HTML)",
 	"tds.package.server.view": "Серверы",
+	"tds.package.server.view.groupConnectedForeground": "Цвет значка группы серверов, содержащей подключенную среду.",
 	"tds.package.properties.program.description.web": "Имя программы / функции",
 	"tds.package.properties.trace.description.web": "Включить ведение журнала для протокола адаптера отладки.",
 	"tds.package.properties.smartclientUrl.description": "URL-адрес SmartClient HTML.",

--- a/src/serverItem.ts
+++ b/src/serverItem.ts
@@ -27,6 +27,25 @@ export class ServerGroupItem extends vscode.TreeItem {
     super(groupLabel(groupPath), collapsibleState);
   }
 
+  /**
+   * A group is "connected" when it directly or indirectly (nested groups)
+   * contains the server that is currently connected, so the folder color
+   * can be extended up the whole path (Ediouro > Homologação > EDI_HOM).
+   */
+  public get hasConnectedServer(): boolean {
+    return this.children.some((child) => {
+      if (child instanceof ServerGroupItem) {
+        return child.hasConnectedServer;
+      }
+
+      if (child instanceof ServerItem) {
+        return child.isConnected;
+      }
+
+      return false;
+    });
+  }
+
   iconPath = new vscode.ThemeIcon("folder");
   tooltip = this.groupPath;
   contextValue = "serverGroup";

--- a/src/serverItem.ts
+++ b/src/serverItem.ts
@@ -98,6 +98,20 @@ export class ServerItem extends vscode.TreeItem {
   };
 
   contextValue = this.isConnected ? "serverItem" : "serverItemNotConnected";
+
+  /**
+   * iconPath/contextValue above are only evaluated once, at construction
+   * time. Call this before handing the item back from getTreeItem() so a
+   * connect/disconnect that doesn't trigger a full tree rebuild is still
+   * reflected on the node itself, not just on its parent groups.
+   */
+  refreshState(): void {
+    this.contextValue = this.isConnected ? "serverItem" : "serverItemNotConnected";
+    this.iconPath = {
+      light: vscode.Uri.file(path.join(RESOURCE_LIGHT, serverTypeImage(this))),
+      dark: vscode.Uri.file(path.join(RESOURCE_DARK, serverTypeImage(this))),
+    };
+  }
 }
 
 export class EnvSection extends vscode.TreeItem {
@@ -120,6 +134,16 @@ export class EnvSection extends vscode.TreeItem {
   tooltip = environmentTypeString(this);
 
   contextValue = this.isCurrent ? "envSection" : "envSectionNotCurrent";
+
+  /** See ServerItem.refreshState(): keeps this node in sync outside a full tree rebuild. */
+  refreshState(): void {
+    this.contextValue = this.isCurrent ? "envSection" : "envSectionNotCurrent";
+    this.tooltip = environmentTypeString(this);
+    this.iconPath = {
+      light: vscode.Uri.file(path.join(RESOURCE_LIGHT, environmentTypeImage(this))),
+      dark: vscode.Uri.file(path.join(RESOURCE_DARK, environmentTypeImage(this))),
+    };
+  }
 }
 
 function serverTypeString(type: ServerType): string {

--- a/src/serverItemProvider.ts
+++ b/src/serverItemProvider.ts
@@ -99,6 +99,8 @@ class ServerItemProvider
           ? new vscode.ThemeColor("totvsServerExplorer.groupConnectedForeground")
           : undefined
       );
+    } else if (element instanceof ServerItem || element instanceof EnvSection) {
+      element.refreshState();
     }
 
     return element;

--- a/src/serverItemProvider.ts
+++ b/src/serverItemProvider.ts
@@ -92,6 +92,15 @@ class ServerItemProvider
   }
 
   getTreeItem(element: ServerTreeItem): vscode.TreeItem {
+    if (element instanceof ServerGroupItem) {
+      element.iconPath = new vscode.ThemeIcon(
+        "folder",
+        element.hasConnectedServer
+          ? new vscode.ThemeColor("totvsServerExplorer.groupConnectedForeground")
+          : undefined
+      );
+    }
+
     return element;
   }
 


### PR DESCRIPTION
## Summary
- When a server/environment is connected, only that leaf tree item turned green - with groups collapsed there was no way to tell which group held it without expanding every folder. `ServerGroupItem` now recursively checks whether it (or a nested group) contains the connected server and colors the folder icon with the same green already used for connected server/environment icons, propagating up the whole path (e.g. Ediouro > Homologacao > EDI_HOM).
- The color is exposed as the theme color `totvsServerExplorer.groupConnectedForeground` (added to the existing `contributes.colors`) so it can be customized like any other contributed color.
- Fixes a related staleness bug surfaced while testing this: `ServerItem`/`EnvSection` only computed their icon/contextValue once, at construction time, so a disconnect that does not trigger a full tree rebuild left the server node showing green even after a successful disconnect. Both now expose a `refreshState()` re-invoked from `getTreeItem()` on every render.

## Test plan
- [x] `npx tsc -p ./src --noEmit` - clean
- [x] `node ./esbuild.js` - clean, no warnings
- [x] Manual test via Extension Development Host: connect to a server nested two groups deep - all parent folders turn green when collapsed; disconnect - both the folders and the server node correctly return to the default color

Generated with Claude Code